### PR TITLE
Properly return list of source saved_at values for source

### DIFF
--- a/skyportal/handlers/api/source.py
+++ b/skyportal/handlers/api/source.py
@@ -381,7 +381,19 @@ class SourceHandler(BaseHandler):
             source_list[-1]["alias"] = ""  # placeholder until we get TNS names
             source_list[-1]["luminosity_distance"] = source.luminosity_distance
             source_list[-1]["dm"] = source.dm
-            source_list[-1]["saved_at"] = source.saved_at
+            source_list[-1]["saved_at"] = [
+                s.saved_at
+                for s in (
+                    DBSession()
+                    .query(Source.saved_at)
+                    .filter(
+                        Source.obj_id == source_list[-1]["id"],
+                        Source.group_id.in_(user_accessible_group_ids),
+                    )
+                    .order_by(Source.saved_at.desc())
+                    .all()
+                )
+            ]
             source_list[-1][
                 "angular_diameter_distance"
             ] = source.angular_diameter_distance

--- a/static/js/components/GroupSources.jsx
+++ b/static/js/components/GroupSources.jsx
@@ -43,6 +43,9 @@ const useStyles = makeStyles((theme) => ({
     overflowY: "scroll",
     padding: "0.5rem 0",
   },
+  tableGrid: {
+    width: "100%",
+  },
 }));
 
 const GroupSources = ({ route }) => {
@@ -118,7 +121,7 @@ const GroupSources = ({ route }) => {
                     id,
                     author,
                     author_info,
-                    saved_at,
+                    created_at,
                     text,
                     attachment_name,
                     groups: comment_groups,
@@ -141,7 +144,7 @@ const GroupSources = ({ route }) => {
                             </span>
                           </span>
                           <span className={styles.commentTime}>
-                            {dayjs().to(dayjs.utc(`${saved_at}Z`))}
+                            {dayjs().to(dayjs.utc(`${created_at}Z`))}
                           </span>
                           <div className={styles.commentUserGroup}>
                             <Tooltip
@@ -263,7 +266,7 @@ const GroupSources = ({ route }) => {
 
   const renderDateSaved = (dataIndex) => {
     const source = sources[dataIndex];
-    return <div key={`${source.id}_date_saved`}>{source.saved_at}</div>;
+    return <div key={`${source.id}_date_saved`}>{source.saved_at[0]}</div>;
   };
 
   // This is just passed to MUI datatables options -- not meant to be instantiated directly.
@@ -406,7 +409,7 @@ const GroupSources = ({ route }) => {
               </Typography>
             </div>
           </Grid>
-          <Grid item>
+          <Grid item className={classes.tableGrid}>
             <MUIDataTable
               title="Sources"
               columns={columns}

--- a/static/js/components/GroupSources.jsx
+++ b/static/js/components/GroupSources.jsx
@@ -349,7 +349,7 @@ const GroupSources = ({ route }) => {
       },
     },
     {
-      name: "Date Saved",
+      name: "Latest Date Saved",
       options: {
         filter: false,
         customBodyRenderLite: renderDateSaved,


### PR DESCRIPTION
- There will actually be multiple saved_at dates for a source (one per each group the source is saved to) so I return that as an array and display the latest saved at date
- Comments have created_at instead of saved_at so I changed that in the comment list 
- Make group sources table fill screen by styling the containing grid